### PR TITLE
Add ability to check line and column of warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ testRule('always', function(tr) {
   tr.notOk('a { }', rejectionMessage, 'rule block with a single space');
   tr.notOk('a {\n}', rejectionMessage, 'rule block with a newline');
   tr.notOk('@media print {}', rejectionMessage, 'empty at-rule block');
-  tr.notOk('@media print { a {} }', rejectionMessage, 'at-rule block with an empty rule block');
+  tr.notOk('@media print { a {} }', {
+    message: rejectionMessage,
+    line: 6,
+    column: 3,
+  }, 'at-rule block with an empty rule block');
 });
 ```
 
@@ -59,35 +63,37 @@ css: "a {}"
 rule: my-no-empty-blocks-rule
 options: "always"
 ok 5 empty rule block should warn
-ok 6 empty rule block should report "Please, no empty blocks!"
+ok 6 empty rule block warning message should be "Please, no empty blocks!"
 #
 css: "a { }"
 rule: my-no-empty-blocks-rule
 options: "always"
 ok 7 rule block with a single space should warn
-ok 8 rule block with a single space should report "Please, no empty blocks!"
+ok 8 rule block with a single space warning message should be "Please, no empty blocks!"
 #
 css: "a {\n}"
 rule: my-no-empty-blocks-rule
 options: "always"
 ok 9 rule block with a newline should warn
-ok 10 rule block with a newline should report "Please, no empty blocks!"
+ok 10 rule block with a newline warning message should be "Please, no empty blocks!"
 #
 css: "@media print {}"
 rule: my-no-empty-blocks-rule
 options: "always"
 ok 11 empty at-rule block should warn
-ok 12 empty at-rule block should report "Please, no empty blocks!"
+ok 12 empty at-rule block warning message should be "Please, no empty blocks!"
 #
 css: "@media print { a {} }"
 rule: my-no-empty-blocks-rule
 options: "always"
 ok 13 at-rule block with an empty rule block should warn
-ok 14 at-rule block with an empty rule block should report "Please, no empty blocks!"
+ok 14 at-rule block with an empty rule block warning message should be "Please, no empty blocks!"
+ok 15 at-rule block with an empty rule block warning should be at line 6
+ok 16 at-rule block with an empty rule block warning should be at column 3
 
-1..14
-# tests 14
-# pass  14
+1..16
+# tests 16
+# pass  16
 
 # ok
 ```

--- a/index.js
+++ b/index.js
@@ -60,19 +60,31 @@ module.exports = function(rule, ruleName, testerOptions) {
      * with the expected warning message.
      *
      * @param {string} cssString
-     * @param {string} warningMessage
+     * @param {string|object} warning
+     * @param {string} [warning.message]
+     * @param {string} [warning.line]
+     * @param {string} [warning.column]
      * @param {string} [description]
      */
-    function notOk(cssString, warningMessage, description) {
+    function notOk(cssString, warning, description) {
       test(testTitleStr(cssString), function(t) {
+        var warningMessage = (typeof warning === 'string')
+          ? warning
+          : warning.message;
         var result = postcssProcess(cssString);
         var warnings = result.warnings();
         t.equal(warnings.length, 1, prepender(description, 'should warn'));
         if (warnings.length === 1) {
           t.equal(warnings[0].text, warningMessage,
-            prepender(description, 'should report "' + warningMessage + '"'));
-        } else {
-          t.pass('no warning to test');
+            prepender(description, 'warning message should be "' + warningMessage + '"'));
+          if (warning.line) {
+            t.equal(warnings[0].line, warning.line,
+              prepender(description, 'warning should be at line ' + warning.line));
+          }
+          if (warning.column) {
+            t.equal(warnings[0].column, warning.column,
+              prepender(description, 'warning should be at column ' + warning.column));
+          }
         }
         t.end();
       });

--- a/test/visual.js
+++ b/test/visual.js
@@ -11,6 +11,8 @@ function noEmptyBlocksRule() {
       if (statement.nodes !== undefined && statement.nodes.length === 0) {
         result.warn('Please, no empty blocks!', {
           node: statement,
+          line: 6,
+          column: 3,
         });
       }
     }
@@ -31,5 +33,9 @@ testRule('always', function(tr) {
   tr.notOk('a { }', rejectionMessage, 'rule block with a single space');
   tr.notOk('a {\n}', rejectionMessage, 'rule block with a newline');
   tr.notOk('@media print {}', rejectionMessage, 'empty at-rule block');
-  tr.notOk('@media print { a {} }', rejectionMessage, 'at-rule block with an empty rule block');
+  tr.notOk('@media print { a {} }', {
+    message: rejectionMessage,
+    line: 6,
+    column: 3,
+  }, 'at-rule block with an empty rule block');
 });


### PR DESCRIPTION
This is in order to support https://github.com/stylelint/stylelint/issues/133.

With PostCSS 5 we can report more accurate line/column positions for warnings. These are attached the warning as `line` and `column` props. This PR adds the ability to test the line/column props of a warning, in addition to its message, in order to ensure the right positions are being reported.

@jeddy3 What do you think?
