### PR TITLE
ESLint 2.x

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "comma-dangle": [2, "always-multiline"],
     "comma-style": 2,
     "consistent-return": 0,
+    "keyword-spacing": 2,
     "curly": 0,
     "no-console": 0,
     "no-lonely-if": 2,
@@ -19,7 +20,6 @@
     "no-use-before-define": [2, "nofunc"],
     "quotes": [2, "single"],
     "space-before-function-paren": [2, "never"],
-    "space-after-keywords": [2, "always"],
     "space-before-blocks": [2, "always"],
     "space-in-parens": [2, "never"],
     "space-unary-ops": 2

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tape": "^4.2.0"
   },
   "devDependencies": {
-    "eslint": "2.1.0",
+    "eslint": "^2.4.0",
     "postcss-scss": "0.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tape": "^4.2.0"
   },
   "devDependencies": {
-    "eslint": "1.9.0",
+    "eslint": "2.1.0",
     "postcss-scss": "0.1.3"
   }
 }


### PR DESCRIPTION
Update to ESLint 2.x per [migration guide](http://eslint.org/docs/user-guide/migrating-to-2.0.0)
- [x] Update `package.json`
- [x] Use `keyword-spacing` rule over now deprecated `space-after-keywords` rule
- [ ] Review existing and new ESLint 2.0 rules for `eslint:recommended`

In 2.0.0, the following [11 rules](http://eslint.org/docs/user-guide/migrating-to-2.0.0#new-rules-in-eslintrecommended) were added to `"eslint:recommended"`:
- [constructor-super](http://eslint.org/docs/rules/constructor-super)
- [no-case-declarations](http://eslint.org/docs/rules/no-case-declarations)
- [no-class-assign](http://eslint.org/docs/rules/no-class-assign)
- [no-const-assign](http://eslint.org/docs/rules/no-const-assign)
- [no-dupe-class-members](http://eslint.org/docs/rules/no-dupe-class-members)
- [no-empty-pattern](http://eslint.org/docs/rules/no-empty-pattern)
- [no-new-symbol](http://eslint.org/docs/rules/no-new-symbol)
- [no-self-assign](http://eslint.org/docs/rules/no-self-assign)
- [no-this-before-super](http://eslint.org/docs/rules/no-this-before-super)
- [no-unexpected-multiline](http://eslint.org/docs/rules/no-unexpected-multiline)
- [no-unused-labels](http://eslint.org/docs/rules/no-unused-labels)

*\* `npm test` currently pass as is
